### PR TITLE
fix: add directory renaming for non-.NET projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Seed Project Renamer
 
-A specialized utility for renaming and bootstrapping seed projects after cloning. This tool renames all occurrences of the seed project name across files and directories, supporting multiple naming conventions (kebab-case, PascalCase, camelCase, snake_case). It works with any seed project by explicitly specifying the source project name.
+A specialized utility for renaming and bootstrapping seed projects after cloning. This tool renames all occurrences of the seed project name across files and directories, supporting multiple naming conventions (kebab-case, PascalCase, camelCase, snake_case). It automatically renames directories that match the seed project name and works with any seed project by explicitly specifying the source project name.
 
 ## Installation
 
@@ -77,11 +77,12 @@ npx @dwkerwin/seed-project-renamer --from seed-csharp-api --dotnet MyNewApi
 ## How It Works
 
 The tool:
-1. **Takes the source seed project name** via `--from` parameter (required)
-2. **Replaces all occurrences** of that seed name with your new project name
-3. **Handles multiple naming formats** (kebab-case, PascalCase, camelCase, snake_case) 
-4. **Updates package.json files** and removes initialization scripts
-5. **Works directory by directory** - run multiple times for multi-service projects
+1. **Takes the source seed project name** via `--from` parameter (auto-detects if not provided)
+2. **Replaces all occurrences** of that seed name with your new project name in file contents
+3. **Renames directories** that match the seed project name (in any naming format)
+4. **Handles multiple naming formats** (kebab-case, PascalCase, camelCase, snake_case) 
+5. **Updates package.json files** and removes initialization scripts
+6. **Works with any project structure** - handles both single and multi-service projects
 
 ## Supported Seed Projects
 

--- a/rename.js
+++ b/rename.js
@@ -326,8 +326,10 @@ by looking for seed-* names in package.json files, or by using the directory nam
     console.log(`Made ${stats.totalReplacements} replacements\n`);
     
     // Rename directories and files
+    console.log('🔄 Renaming directories and files...');
+    
     if (isDotNet) {
-      // Rename directories
+      // Rename directories for .NET projects
       renameIfExists(
         path.join(process.cwd(), seedConfig.camel), 
         path.join(process.cwd(), nameCamel)
@@ -353,6 +355,33 @@ by looking for seed-* names in package.json files, or by using the directory nam
       renameIfExists(
         path.join(process.cwd(), `${nameCamel}.Tests`, `${seedConfig.camel}.Tests.csproj`), 
         path.join(process.cwd(), `${nameCamel}.Tests`, `${nameCamel}.Tests.csproj`)
+      );
+    } else {
+      // Rename directories for non-.NET projects (Node.js, etc.)
+      // Check for directories that match the seed project name in various formats
+      
+      // Try kebab-case directory (most common for Node.js projects)
+      renameIfExists(
+        path.join(process.cwd(), seedConfig.kebab),
+        path.join(process.cwd(), name.toLowerCase())
+      );
+      
+      // Try PascalCase directory
+      renameIfExists(
+        path.join(process.cwd(), seedConfig.pascal),
+        path.join(process.cwd(), namePascal)
+      );
+      
+      // Try CamelCase directory
+      renameIfExists(
+        path.join(process.cwd(), seedConfig.camel),
+        path.join(process.cwd(), nameCamel)
+      );
+      
+      // Try snake_case directory
+      renameIfExists(
+        path.join(process.cwd(), seedConfig.snake),
+        path.join(process.cwd(), nameSnake)
       );
     }
     


### PR DESCRIPTION
- Add missing directory renaming logic for Node.js and other project types
- Previously only .NET projects had directory renaming support
- Now renames directories matching seed project name in all naming formats
- Update README to clarify directory renaming capability