### PR TITLE
fix(rename): Ensure case-insensitive content replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dwkerwin/seed-project-renamer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A utility for bootstrapping seed projects by consistently renaming all references across files, supporting multiple naming conventions and explicit source project specification via --from parameter",
   "main": "index.js",
   "bin": {

--- a/rename.js
+++ b/rename.js
@@ -24,6 +24,7 @@ function generateSeedVariations(seedName) {
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join('');
   const snake = seedName.replace(/-/g, '_').toLowerCase();
+  const lowerKebab = seedName.toLowerCase();
   
   // Create shortened version for target group name if needed
   let tg = seedName;
@@ -32,7 +33,7 @@ function generateSeedVariations(seedName) {
   }
   tg += "-tg";
   
-  return { kebab, pascal, camel, snake, tg };
+  return { kebab, pascal, camel, snake, tg, lowerKebab };
 }
 
 // Auto-detect seed project name from package.json or folder name
@@ -257,6 +258,7 @@ by looking for seed-* names in package.json files, or by using the directory nam
   // Define replacements
   const replacements = [
     { from: seedConfig.kebab, to: name.toLowerCase() },
+    { from: seedConfig.lowerKebab, to: name.toLowerCase() },
     { from: seedConfig.pascal, to: namePascal },
     { from: seedConfig.camel, to: nameCamel },
     { from: seedConfig.snake, to: nameSnake },


### PR DESCRIPTION
Adds an explicit lowercase version of the seed name to the replacement map.

This fixes a bug where providing a mixed-case seed name (e.g., `Seed-Dotnet-Project`) would cause content replacement to fail, as the file contents are often all lowercase (`seed-dotnet-project`).

This change is backward-compatible and does not affect projects that already use all-lowercase seed names.